### PR TITLE
docs: document tool-calling, thinking-mode gotcha, measured concurrency=8

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,22 @@ downloads) — no manual fetching. Set `HF_TARGET_REPO` / `HF_DRAFT_REPO` in
   see the 24 GB notes)
 
 Concurrency note: the server generates one request at a time (batch-1
-speculative decoding); concurrent requests queue automatically.
+speculative decoding); concurrent requests queue automatically. Measured on
+DGX Spark with `DRAFT=dflash2`: 8 concurrent requests ran fully sequentially
+(no batching benefit), aggregate throughput ~16.7 tok/s at that concurrency
+— plan capacity accordingly if your workload is concurrent rather than
+single-request.
+
+Reasoning note: the server always reasons — there is currently no way to
+disable it. `chat_template_kwargs.enable_thinking` (the vLLM/SGLang
+convention) is silently ignored. The reasoning trace comes back in a
+separate `reasoning_content` field (both in the full response and in each
+streamed `delta`), but it is **not** a separate token budget: reasoning and
+visible `content` both draw from the same `max_tokens`. With a tight budget
+(e.g. `max_tokens: 16` on a short-answer prompt) I got a response with no
+`content` at all, entirely consumed by the reasoning trace — clients
+expecting a quick, cheap warmup/probe call should budget generously rather
+than assuming a short `max_tokens` implies a short wait.
 
 ## 24 GB GPUs (RTX 3090 / 4090)
 
@@ -146,6 +161,37 @@ RTX-class notes (vs the DGX Spark the numbers above were measured on):
   memory than a 24 GB card has. `DRAFT=none` frees the draft memory too, but
   gives up speculative decoding — `DRAFT=mtp` already dominates it on both
   memory and speed.
+
+## Tool calling
+
+OpenAI-style `tools` / `tool_choice` work (referenced in the file table
+above but not otherwise documented here). Verified request/response shape:
+
+```bash
+curl http://localhost:8888/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen3.8-27b-exl3-3.5bpw-wm",
+    "messages": [{"role": "user", "content": "What is the weather in Lyon?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+      }
+    }],
+    "tool_choice": "auto",
+    "max_tokens": 300
+  }'
+```
+
+Returns a normal OpenAI `tool_calls` array (`finish_reason: "tool_calls"`,
+`message.content: null`) alongside the usual `reasoning_content`. The
+`model` id in responses doesn't necessarily match `HF_TARGET_REPO` or
+`MODEL_DIR` verbatim (I saw `qwen3.8-27b-exl3-3.5bpw-wm` for
+`MODEL_DIR=models/Qwen3.8-27B-EXL3-3.5bpw`) — check `/v1/models` rather
+than assuming the id a client should send.
 
 ## Model cards
 


### PR DESCRIPTION
## Context

Ran this alongside `albond/DenseSpark-Qwen3.8-27B` on my own DGX Spark this session (different runtime — vLLM vs exllamav3 — but same model/hardware class), so I had a working single-stream cross-check and figured a few gaps I hit were worth documenting.

## What's added

- **Tool calling**: referenced in the file table (`tools/serve_openai.py`) but not documented anywhere with an example. Added a verified curl request/response showing the `tools`/`tool_choice` shape and the `tool_calls` response.
- **Reasoning/thinking mode**: `chat_template_kwargs.enable_thinking` (the vLLM/SGLang convention) is silently ignored — the server always reasons, and the `reasoning_content` trace shares the `max_tokens` budget with `content` rather than getting its own allowance. I hit this directly: a tight-budget warmup probe came back with no content at all, entirely consumed by reasoning. Documented so others don't have to rediscover it.
- **Concurrency=8, measured**: quantifies the existing "one at a time" note in the README — fired 8 concurrent requests against `DRAFT=dflash2` on a DGX Spark, all ran fully sequentially (no batching), aggregate ~16.7 tok/s. Useful context for anyone sizing a concurrent-traffic deployment against the single-request numbers already in the README.

No code changes — README only. Happy to adjust wording/scope if any of this reads as out of place for the doc.