### PR TITLE
Native Windows launchers (start.ps1/stop.ps1) + transformers dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 models/
 # runtime: server conversation log
 jobs.jsonl
+tools/__pycache__/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ cp .env.example .env      # edit: context, GPU memory
                           # downloads weights, serves http://localhost:8888/v1
 ```
 
+On native Windows (PowerShell 7+), use `start.ps1` / `stop.ps1` instead
+(same `.env`). First run needs a VS Developer prompt (`vcvars64.bat`,
+x64) so `cl.exe` is on PATH for the CUDA extension build. On a 3090 set
+`CACHE_QUANT=4` (Hadamard int4; `nvfp4`/`fp8` need sm >= 8.9).
+
 `start.sh` is self-bootstrapping: on first run it creates `.venv`, installs
 GPU torch and pip-installs the exllamav3 engine from this fork (all of
 DFlash2/MTP drafting, NVFP4/FP8 KV and the aarch64 GB10 port are fork

--- a/start.ps1
+++ b/start.ps1
@@ -1,45 +1,70 @@
 #!/usr/bin/env pwsh
 # Start the OpenAI-compatible exllamav3 server (tools/serve_openai.py).
-# Native Windows port of start.sh. Configuration lives in .env.
+# Native Windows port of start.sh. Configuration lives in .env; environment
+# variables (MODEL_DIR, HOST, PORT, CONTEXT_SIZE, CACHE_QUANT, DRAFT) win
+# over .env for every knob — stop.sh convention, and how beellama-tui
+# passes per-launch config.
 # First run needs cl.exe + nvcc on PATH: launch from a VS Developer
 # prompt (vcvars64.bat, x64) so the CUDA extension precompile can build.
 $ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
-if (-not (Test-Path tools/serve_openai.py)) {
+if (-not (Test-Path tools/serve_openai.py))
+{
     Write-Error 'tools/serve_openai.py not found. Run from the engine repo or deployment kit.'
     exit 1
 }
-if (-not (Test-Path .env)) {
+if (-not (Test-Path .env) -and -not $env:MODEL_DIR)
+{
     Copy-Item .env.example .env
     Write-Host 'Created .env from .env.example. Edit it (HF_TOKEN, MODEL_DIR) and rerun.'
     exit 1
 }
 
-# Load .env (KEY=VALUE, # comments). Same file format as start.sh.
+# Load .env (KEY=VALUE, # comments) when present. Environment variables win
+# over .env for every knob below (see header).
 $cfg = @{}
-Get-Content .env | ForEach-Object {
-    if ($_ -match '^\s*#' -or $_ -notmatch '=') {
-        return
+if (Test-Path .env)
+{
+    Get-Content .env | ForEach-Object {
+        if ($_ -match '^\s*#' -or $_ -notmatch '=')
+        {
+            return
+        }
+        $k, $v = $_.Split('=', 2)
+        $cfg[$k.Trim()] = $v.Trim()
     }
-    $k, $v = $_.Split('=', 2)
-    $cfg[$k.Trim()] = $v.Trim()
 }
-if ($cfg['HF_TOKEN']) {
+if (-not $env:HF_TOKEN -and $cfg['HF_TOKEN'])
+{
     $env:HF_TOKEN = $cfg['HF_TOKEN']
 }
 
-$VenvPython = Join-Path $PWD '.venv/Scripts/python.exe'
-function Test-EngineImport {
-    & $VenvPython -c 'import torch, exllamav3, aiohttp, huggingface_hub, transformers' 2>$null
+function Test-EngineImport($py)
+{
+    & $py -c 'import torch, exllamav3, aiohttp, huggingface_hub, transformers' 2>$null
     return $LASTEXITCODE -eq 0
 }
-if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport)) {
+
+$VenvPython = Join-Path $PWD '.venv/Scripts/python.exe'
+# Prefer the engine repo's built venv when it imports cleanly: the engine
+# checkout next door boots it, and reusing it keeps TUI/manual launches off
+# the first-run setup path entirely.
+$EngineVenvPython = Join-Path $PSScriptRoot '..\exllamav3\.venv\Scripts\python.exe'
+if ((Test-Path $EngineVenvPython) -and (Test-EngineImport $EngineVenvPython))
+{
+    $VenvPython = $EngineVenvPython
+    Write-Host "Using engine venv: $EngineVenvPython"
+}
+
+if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython))
+{
     Write-Host 'First-run setup (later runs skip to the model):'
     python -m venv .venv
     & $VenvPython -m pip install --quiet --upgrade pip setuptools wheel typing_extensions packaging
     $torchIndex = $cfg['TORCH_INDEX_URL']
-    if (-not $torchIndex) {
+    if (-not $torchIndex)
+    {
         $torchIndex = 'https://download.pytorch.org/whl/cu130'
     }
     & $VenvPython -m pip install torch --extra-index-url $torchIndex
@@ -51,14 +76,17 @@ if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport)) {
     & $VenvPython -m pip install tokenizers numpy rich typing_extensions safetensors ninja pillow pyyaml marisa_trie pydantic 'llguidance>=1.7.0' transformers
     # The precompile needs the x64 MSVC tools + matching env. Without cl.exe
     # the extension cannot build, so stop instead of serving a broken venv.
-    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue))
+    {
         Write-Error 'cl.exe not on PATH. Rerun from a VS Developer prompt (vcvars64.bat, x64) for the CUDA precompile.'
         exit 1
     }
-    if (-not $env:CUDA_HOME) {
+    if (-not $env:CUDA_HOME)
+    {
         $env:CUDA_HOME = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3'
     }
-    if (-not $env:MAX_JOBS) {
+    if (-not $env:MAX_JOBS)
+    {
         $env:MAX_JOBS = '4'
     }
     $env:DISTUTILS_USE_SDK = '1'
@@ -68,58 +96,90 @@ if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport)) {
 }
 
 $PYTHON = $VenvPython
-$env:PATH = (Join-Path $PWD '.venv/Scripts') + ';' + $env:PATH
+$env:PATH = (Join-Path $PSScriptRoot '.venv/Scripts') + ';' + $env:PATH
 
-$MODEL_DIR = $cfg['MODEL_DIR']; if (-not $MODEL_DIR) {
-    Write-Error 'MODEL_DIR must be set in .env'; exit 1
+$MODEL_DIR = $env:MODEL_DIR; if (-not $MODEL_DIR)
+{ $MODEL_DIR = $cfg['MODEL_DIR']
 }
-$PORT = $cfg['PORT']; if (-not $PORT) {
-    $PORT = '8888'
+if (-not $MODEL_DIR)
+{
+    Write-Error 'MODEL_DIR must be set in .env or MODEL_DIR env'; exit 1
 }
-$HOST_ = $cfg['HOST']; if (-not $HOST_) {
-    $HOST_ = '127.0.0.1'
+$PORT = $env:PORT; if (-not $PORT)
+{ $PORT = $cfg['PORT']
 }
-$CONTEXT_SIZE = [int]($cfg['CONTEXT_SIZE']); if (-not $CONTEXT_SIZE) {
-    $CONTEXT_SIZE = 65536
+if (-not $PORT)
+{ $PORT = '8888'
 }
-$GPU_MEM_GB = $cfg['GPU_MEM_GB']
-if (-not $GPU_MEM_GB) {
+$HOST_ = $env:HOST; if (-not $HOST_)
+{ $HOST_ = $cfg['HOST']
+}
+if (-not $HOST_)
+{ $HOST_ = '127.0.0.1'
+}
+$CONTEXT_SIZE = $env:CONTEXT_SIZE; if (-not $CONTEXT_SIZE)
+{ $CONTEXT_SIZE = $cfg['CONTEXT_SIZE']
+}
+$CONTEXT_SIZE = [int]($CONTEXT_SIZE); if (-not $CONTEXT_SIZE)
+{ $CONTEXT_SIZE = 65536
+}
+$GPU_MEM_GB = $env:GPU_MEM_GB; if (-not $GPU_MEM_GB)
+{ $GPU_MEM_GB = $cfg['GPU_MEM_GB']
+}
+if (-not $GPU_MEM_GB)
+{
     $vram = (nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>$null | Select-Object -First 1)
-    if ([int]$vram -gt 0) {
+    if ([int]$vram -gt 0)
+    {
         $GPU_MEM_GB = [string]([int]$vram / 1024 - 2)
-    } else {
+    } else
+    {
         $GPU_MEM_GB = '22'
     }
     Write-Host "GPU_MEM_GB not set. Budget: $GPU_MEM_GB GB (override in .env)"
 }
-$CACHE_QUANT = $cfg['CACHE_QUANT']; if (-not $CACHE_QUANT) {
-    $CACHE_QUANT = 'none'
+$CACHE_QUANT = $env:CACHE_QUANT; if (-not $CACHE_QUANT)
+{ $CACHE_QUANT = $cfg['CACHE_QUANT']
 }
-$CPU_CACHE_GB = $cfg['CPU_CACHE_GB']; if (-not $CPU_CACHE_GB) {
+if (-not $CACHE_QUANT)
+{ $CACHE_QUANT = 'none'
+}
+$CPU_CACHE_GB = $cfg['CPU_CACHE_GB']; if (-not $CPU_CACHE_GB)
+{
     $CPU_CACHE_GB = '0'
 }
 
-$DRAFT = $cfg['DRAFT']
-if (-not $DRAFT) {
-    if ($cfg['DRAFT_DIR'] -eq 'none') {
+$DRAFT = $env:DRAFT; if (-not $DRAFT)
+{ $DRAFT = $cfg['DRAFT']
+}
+if (-not $DRAFT)
+{
+    if ($cfg['DRAFT_DIR'] -eq 'none')
+    {
         $DRAFT = 'none'
-    } elseif ($cfg['DRAFT_DIR']) {
+    } elseif ($cfg['DRAFT_DIR'])
+    {
         $DRAFT = 'dflash2'
-    } else {
+    } else
+    {
         $DRAFT = 'mtp'
     }
 }
 $DRAFT = $DRAFT.ToLower()
 
-$HF_TARGET_REPO = $cfg['HF_TARGET_REPO']; if (-not $HF_TARGET_REPO) {
+$HF_TARGET_REPO = $cfg['HF_TARGET_REPO']; if (-not $HF_TARGET_REPO)
+{
     $HF_TARGET_REPO = 'Mia-AiLab/Qwen3.8-27B-EXL3-3.5bpw'
 }
-$HF_DRAFT_REPO = $cfg['HF_DRAFT_REPO']; if (-not $HF_DRAFT_REPO) {
+$HF_DRAFT_REPO = $cfg['HF_DRAFT_REPO']; if (-not $HF_DRAFT_REPO)
+{
     $HF_DRAFT_REPO = 'Mia-AiLab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
 }
 
-function Get-Model($repo, $dir, $label) {
-    if ((Test-Path (Join-Path $dir 'config.json')) -and (Get-ChildItem (Join-Path $dir '*.safetensors') -ErrorAction SilentlyContinue)) {
+function Get-Model($repo, $dir, $label)
+{
+    if ((Test-Path (Join-Path $dir 'config.json')) -and (Get-ChildItem (Join-Path $dir '*.safetensors') -ErrorAction SilentlyContinue))
+    {
         Write-Host "$label`: $dir present. Skip download."
         return
     }
@@ -129,27 +189,35 @@ function Get-Model($repo, $dir, $label) {
 }
 
 Get-Model -Repo $HF_TARGET_REPO -Dir $MODEL_DIR -Label 'target model'
-switch ($DRAFT) {
-    'mtp' {
+switch ($DRAFT)
+{
+    'mtp'
+    {
     }
-    'dflash2' {
+    'dflash2'
+    {
         $draftDir = $cfg['DRAFT_DIR']
-        if (-not $draftDir -or $draftDir -eq 'none') {
+        if (-not $draftDir -or $draftDir -eq 'none')
+        {
             $draftDir = 'models/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
         }
         Get-Model -Repo $HF_DRAFT_REPO -Dir $draftDir -Label 'DFlash2 draft'
         $cfg['DRAFT_DIR'] = $draftDir
     }
-    'none' {
+    'none'
+    {
     }
-    default {
+    default
+    {
         Write-Error "DRAFT must be mtp, dflash2, or none (got: $DRAFT)"; exit 1
     }
 }
 
-if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-1m.json'))) {
+if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-1m.json')))
+{
     $conf = Get-Content (Join-Path $MODEL_DIR 'config.json') -Raw
-    if ($conf -notmatch 'rope_scaling') {
+    if ($conf -notmatch 'rope_scaling')
+    {
         Copy-Item (Join-Path $MODEL_DIR 'config.yarn-1m.json') (Join-Path $MODEL_DIR 'config.json')
         Write-Host 'CONTEXT_SIZE > 262k: switched config.json to YaRN 1M variant.'
     }
@@ -157,24 +225,29 @@ if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-
 
 $cmd = @($PYTHON, '-u', 'tools/serve_openai.py', '--model', $MODEL_DIR,
     '--host', $HOST_, '--port', $PORT, '--cache_size', "$CONTEXT_SIZE", '--grid_size', "$GPU_MEM_GB")
-if ($CACHE_QUANT -ne 'none') {
+if ($CACHE_QUANT -ne 'none')
+{
     $cmd += @('--cache_quant', $CACHE_QUANT)
 }
-switch ($DRAFT) {
-    'mtp' {
+switch ($DRAFT)
+{
+    'mtp'
+    {
         $cmd += @('--draft_model', 'mtp')
     }
-    'dflash2' {
+    'dflash2'
+    {
         $cmd += @('--draft_model', $cfg['DRAFT_DIR'])
     }
-    'none' {
+    'none'
+    {
         $cmd += @('--draft_model', 'none')
     }
 }
-if ($CPU_CACHE_GB -ne '0') {
+if ($CPU_CACHE_GB -ne '0')
+{
     $cmd += @('--cpu_cache_size', $CPU_CACHE_GB)
 }
 
 Write-Host "Starting: $($cmd -join ' ')"
 & $cmd[0] $cmd[1..($cmd.Count - 1)]
-

--- a/start.ps1
+++ b/start.ps1
@@ -1,21 +1,19 @@
 #!/usr/bin/env pwsh
 # Start the OpenAI-compatible exllamav3 server (tools/serve_openai.py).
 # Native Windows port of start.sh. Configuration lives in .env; environment
-# variables (MODEL_DIR, HOST, PORT, CONTEXT_SIZE, CACHE_QUANT, DRAFT) win
-# over .env for every knob — stop.sh convention, and how beellama-tui
+# variables (MODEL_DIR, DRAFT_DIR, HOST, PORT, CONTEXT_SIZE, CACHE_QUANT, DRAFT) win
+# over .env for every knob ΓÇö stop.sh convention, and how beellama-tui
 # passes per-launch config.
 # First run needs cl.exe + nvcc on PATH: launch from a VS Developer
 # prompt (vcvars64.bat, x64) so the CUDA extension precompile can build.
 $ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
-if (-not (Test-Path tools/serve_openai.py))
-{
+if (-not (Test-Path tools/serve_openai.py)) {
     Write-Error 'tools/serve_openai.py not found. Run from the engine repo or deployment kit.'
     exit 1
 }
-if (-not (Test-Path .env) -and -not $env:MODEL_DIR)
-{
+if (-not (Test-Path .env) -and -not $env:MODEL_DIR) {
     Copy-Item .env.example .env
     Write-Host 'Created .env from .env.example. Edit it (HF_TOKEN, MODEL_DIR) and rerun.'
     exit 1
@@ -24,24 +22,20 @@ if (-not (Test-Path .env) -and -not $env:MODEL_DIR)
 # Load .env (KEY=VALUE, # comments) when present. Environment variables win
 # over .env for every knob below (see header).
 $cfg = @{}
-if (Test-Path .env)
-{
+if (Test-Path .env) {
     Get-Content .env | ForEach-Object {
-        if ($_ -match '^\s*#' -or $_ -notmatch '=')
-        {
+        if ($_ -match '^\s*#' -or $_ -notmatch '=') {
             return
         }
         $k, $v = $_.Split('=', 2)
         $cfg[$k.Trim()] = $v.Trim()
     }
 }
-if (-not $env:HF_TOKEN -and $cfg['HF_TOKEN'])
-{
+if (-not $env:HF_TOKEN -and $cfg['HF_TOKEN']) {
     $env:HF_TOKEN = $cfg['HF_TOKEN']
 }
 
-function Test-EngineImport($py)
-{
+function Test-EngineImport($py) {
     & $py -c 'import torch, exllamav3, aiohttp, huggingface_hub, transformers' 2>$null
     return $LASTEXITCODE -eq 0
 }
@@ -51,20 +45,17 @@ $VenvPython = Join-Path $PWD '.venv/Scripts/python.exe'
 # checkout next door boots it, and reusing it keeps TUI/manual launches off
 # the first-run setup path entirely.
 $EngineVenvPython = Join-Path $PSScriptRoot '..\exllamav3\.venv\Scripts\python.exe'
-if ((Test-Path $EngineVenvPython) -and (Test-EngineImport $EngineVenvPython))
-{
+if ((Test-Path $EngineVenvPython) -and (Test-EngineImport $EngineVenvPython)) {
     $VenvPython = $EngineVenvPython
     Write-Host "Using engine venv: $EngineVenvPython"
 }
 
-if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython))
-{
+if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython)) {
     Write-Host 'First-run setup (later runs skip to the model):'
     python -m venv .venv
     & $VenvPython -m pip install --quiet --upgrade pip setuptools wheel typing_extensions packaging
     $torchIndex = $cfg['TORCH_INDEX_URL']
-    if (-not $torchIndex)
-    {
+    if (-not $torchIndex) {
         $torchIndex = 'https://download.pytorch.org/whl/cu130'
     }
     & $VenvPython -m pip install torch --extra-index-url $torchIndex
@@ -76,17 +67,14 @@ if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython))
     & $VenvPython -m pip install tokenizers numpy rich typing_extensions safetensors ninja pillow pyyaml marisa_trie pydantic 'llguidance>=1.7.0' transformers
     # The precompile needs the x64 MSVC tools + matching env. Without cl.exe
     # the extension cannot build, so stop instead of serving a broken venv.
-    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue))
-    {
+    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
         Write-Error 'cl.exe not on PATH. Rerun from a VS Developer prompt (vcvars64.bat, x64) for the CUDA precompile.'
         exit 1
     }
-    if (-not $env:CUDA_HOME)
-    {
+    if (-not $env:CUDA_HOME) {
         $env:CUDA_HOME = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3'
     }
-    if (-not $env:MAX_JOBS)
-    {
+    if (-not $env:MAX_JOBS) {
         $env:MAX_JOBS = '4'
     }
     $env:DISTUTILS_USE_SDK = '1'
@@ -98,88 +86,75 @@ if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython))
 $PYTHON = $VenvPython
 $env:PATH = (Split-Path $VenvPython) + ';' + $env:PATH
 
-$MODEL_DIR = $env:MODEL_DIR; if (-not $MODEL_DIR)
-{ $MODEL_DIR = $cfg['MODEL_DIR']
+$MODEL_DIR = $env:MODEL_DIR; if (-not $MODEL_DIR) {
+    $MODEL_DIR = $cfg['MODEL_DIR']
 }
-if (-not $MODEL_DIR)
-{
+if (-not $MODEL_DIR) {
     Write-Error 'MODEL_DIR must be set in .env or MODEL_DIR env'; exit 1
 }
-$PORT = $env:PORT; if (-not $PORT)
-{ $PORT = $cfg['PORT']
+$PORT = $env:PORT; if (-not $PORT) {
+    $PORT = $cfg['PORT']
 }
-if (-not $PORT)
-{ $PORT = '8888'
+if (-not $PORT) {
+    $PORT = '8888'
 }
-$HOST_ = $env:HOST; if (-not $HOST_)
-{ $HOST_ = $cfg['HOST']
+$HOST_ = $env:HOST; if (-not $HOST_) {
+    $HOST_ = $cfg['HOST']
 }
-if (-not $HOST_)
-{ $HOST_ = '127.0.0.1'
+if (-not $HOST_) {
+    $HOST_ = '127.0.0.1'
 }
-$CONTEXT_SIZE = $env:CONTEXT_SIZE; if (-not $CONTEXT_SIZE)
-{ $CONTEXT_SIZE = $cfg['CONTEXT_SIZE']
+$CONTEXT_SIZE = $env:CONTEXT_SIZE; if (-not $CONTEXT_SIZE) {
+    $CONTEXT_SIZE = $cfg['CONTEXT_SIZE']
 }
-$CONTEXT_SIZE = [int]($CONTEXT_SIZE); if (-not $CONTEXT_SIZE)
-{ $CONTEXT_SIZE = 65536
+$CONTEXT_SIZE = [int]($CONTEXT_SIZE); if (-not $CONTEXT_SIZE) {
+    $CONTEXT_SIZE = 65536
 }
-$GPU_MEM_GB = $env:GPU_MEM_GB; if (-not $GPU_MEM_GB)
-{ $GPU_MEM_GB = $cfg['GPU_MEM_GB']
+$GPU_MEM_GB = $env:GPU_MEM_GB; if (-not $GPU_MEM_GB) {
+    $GPU_MEM_GB = $cfg['GPU_MEM_GB']
 }
-if (-not $GPU_MEM_GB)
-{
-    $vram = (nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>$null | Select-Object -First 1)
-    if ([int]$vram -gt 0)
-    {
+if (-not $GPU_MEM_GB) {
+    $vram = (nvidia-smi --query-gpu=memory.total '--format=csv,noheader,nounits' 2>$null | Select-Object -First 1)
+    if ([int]$vram -gt 0) {
         $GPU_MEM_GB = [string]([int]$vram / 1024 - 2)
-    } else
-    {
+    } else {
         $GPU_MEM_GB = '22'
     }
     Write-Host "GPU_MEM_GB not set. Budget: $GPU_MEM_GB GB (override in .env)"
 }
-$CACHE_QUANT = $env:CACHE_QUANT; if (-not $CACHE_QUANT)
-{ $CACHE_QUANT = $cfg['CACHE_QUANT']
+$CACHE_QUANT = $env:CACHE_QUANT; if (-not $CACHE_QUANT) {
+    $CACHE_QUANT = $cfg['CACHE_QUANT']
 }
-if (-not $CACHE_QUANT)
-{ $CACHE_QUANT = 'none'
+if (-not $CACHE_QUANT) {
+    $CACHE_QUANT = 'none'
 }
-$CPU_CACHE_GB = $cfg['CPU_CACHE_GB']; if (-not $CPU_CACHE_GB)
-{
+$CPU_CACHE_GB = $cfg['CPU_CACHE_GB']; if (-not $CPU_CACHE_GB) {
     $CPU_CACHE_GB = '0'
 }
 
-$DRAFT = $env:DRAFT; if (-not $DRAFT)
-{ $DRAFT = $cfg['DRAFT']
+$DRAFT = $env:DRAFT; if (-not $DRAFT) {
+    $DRAFT = $cfg['DRAFT']
 }
-if (-not $DRAFT)
-{
-    if ($cfg['DRAFT_DIR'] -eq 'none')
-    {
+if (-not $DRAFT) {
+    if ($cfg['DRAFT_DIR'] -eq 'none') {
         $DRAFT = 'none'
-    } elseif ($cfg['DRAFT_DIR'])
-    {
+    } elseif ($cfg['DRAFT_DIR']) {
         $DRAFT = 'dflash2'
-    } else
-    {
+    } else {
         $DRAFT = 'mtp'
     }
 }
 $DRAFT = $DRAFT.ToLower()
 
-$HF_TARGET_REPO = $cfg['HF_TARGET_REPO']; if (-not $HF_TARGET_REPO)
-{
+$HF_TARGET_REPO = $cfg['HF_TARGET_REPO']; if (-not $HF_TARGET_REPO) {
     $HF_TARGET_REPO = 'Mia-AiLab/Qwen3.8-27B-EXL3-3.5bpw'
 }
-$HF_DRAFT_REPO = $cfg['HF_DRAFT_REPO']; if (-not $HF_DRAFT_REPO)
-{
+$HF_DRAFT_REPO = $cfg['HF_DRAFT_REPO']; if (-not $HF_DRAFT_REPO) {
     $HF_DRAFT_REPO = 'Mia-AiLab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
 }
 
-function Get-Model($repo, $dir, $label)
-{
-    if ((Test-Path (Join-Path $dir 'config.json')) -and (Get-ChildItem (Join-Path $dir '*.safetensors') -ErrorAction SilentlyContinue))
-    {
+function Get-Model($repo, $dir, $label) {
+    if ((Test-Path (Join-Path $dir 'config.json')) -and (Get-ChildItem (Join-Path $dir '*.safetensors') -ErrorAction SilentlyContinue)) {
         Write-Host "$label`: $dir present. Skip download."
         return
     }
@@ -192,39 +167,31 @@ function Get-Model($repo, $dir, $label)
 }
 
 Get-Model -Repo $HF_TARGET_REPO -Dir $MODEL_DIR -Label 'target model'
-switch ($DRAFT)
-{
-    'mtp'
-    {
+switch ($DRAFT) {
+    'mtp' {
     }
-    'dflash2'
-    {
-        $draftDir = $cfg['DRAFT_DIR']
-        if (-not $draftDir -or $draftDir -eq 'none')
-        {
+    'dflash2' {
+        $draftDir = $env:DRAFT_DIR; if (-not $draftDir)
+        $draftDir =  =~ s/.*/        { $draftDir = $cfg['DRAFT_DIR'] }/r
+        if (-not $draftDir -or $draftDir -eq 'none') {
             $draftDir = 'models/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
         }
         Get-Model -Repo $HF_DRAFT_REPO -Dir $draftDir -Label 'DFlash2 draft'
-        if (-not (Get-ChildItem (Join-Path $draftDir '*.safetensors') -ErrorAction SilentlyContinue))
-        {
+        if (-not (Get-ChildItem (Join-Path $draftDir '*.safetensors') -ErrorAction SilentlyContinue)) {
             Write-Error "DFlash2 draft download failed; refusing to start with an unusable draft model."; exit 1
         }
         $cfg['DRAFT_DIR'] = $draftDir
     }
-    'none'
-    {
+    'none' {
     }
-    default
-    {
+    default {
         Write-Error "DRAFT must be mtp, dflash2, or none (got: $DRAFT)"; exit 1
     }
 }
 
-if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-1m.json')))
-{
+if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-1m.json'))) {
     $conf = Get-Content (Join-Path $MODEL_DIR 'config.json') -Raw
-    if ($conf -notmatch 'rope_scaling')
-    {
+    if ($conf -notmatch 'rope_scaling') {
         Copy-Item (Join-Path $MODEL_DIR 'config.yarn-1m.json') (Join-Path $MODEL_DIR 'config.json')
         Write-Host 'CONTEXT_SIZE > 262k: switched config.json to YaRN 1M variant.'
     }
@@ -232,27 +199,21 @@ if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-
 
 $cmd = @($PYTHON, '-u', 'tools/serve_openai.py', '--model', $MODEL_DIR,
     '--host', $HOST_, '--port', $PORT, '--cache_size', "$CONTEXT_SIZE", '--grid_size', "$GPU_MEM_GB")
-if ($CACHE_QUANT -ne 'none')
-{
+if ($CACHE_QUANT -ne 'none') {
     $cmd += @('--cache_quant', $CACHE_QUANT)
 }
-switch ($DRAFT)
-{
-    'mtp'
-    {
+switch ($DRAFT) {
+    'mtp' {
         $cmd += @('--draft_model', 'mtp')
     }
-    'dflash2'
-    {
+    'dflash2' {
         $cmd += @('--draft_model', $cfg['DRAFT_DIR'])
     }
-    'none'
-    {
+    'none' {
         $cmd += @('--draft_model', 'none')
     }
 }
-if ($CPU_CACHE_GB -ne '0')
-{
+if ($CPU_CACHE_GB -ne '0') {
     $cmd += @('--cpu_cache_size', $CPU_CACHE_GB)
 }
 

--- a/start.ps1
+++ b/start.ps1
@@ -185,6 +185,9 @@ function Get-Model($repo, $dir, $label)
     }
     Write-Host "$label`: download $repo to $dir ..."
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    # huggingface_hub writes .incomplete files under <dir>/.cache/huggingface/download
+    # and fails with FileNotFoundError on Windows when that tree is missing.
+    New-Item -ItemType Directory -Force -Path (Join-Path $dir '.cache\huggingface\download') | Out-Null
     & $PYTHON -c 'from huggingface_hub import snapshot_download; import sys; print(snapshot_download(repo_id=sys.argv[1], local_dir=sys.argv[2]))' $repo $dir
 }
 
@@ -202,6 +205,10 @@ switch ($DRAFT)
             $draftDir = 'models/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
         }
         Get-Model -Repo $HF_DRAFT_REPO -Dir $draftDir -Label 'DFlash2 draft'
+        if (-not (Get-ChildItem (Join-Path $draftDir '*.safetensors') -ErrorAction SilentlyContinue))
+        {
+            Write-Error "DFlash2 draft download failed; refusing to start with an unusable draft model."; exit 1
+        }
         $cfg['DRAFT_DIR'] = $draftDir
     }
     'none'

--- a/start.ps1
+++ b/start.ps1
@@ -96,7 +96,7 @@ if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport $VenvPython))
 }
 
 $PYTHON = $VenvPython
-$env:PATH = (Join-Path $PSScriptRoot '.venv/Scripts') + ';' + $env:PATH
+$env:PATH = (Split-Path $VenvPython) + ';' + $env:PATH
 
 $MODEL_DIR = $env:MODEL_DIR; if (-not $MODEL_DIR)
 { $MODEL_DIR = $cfg['MODEL_DIR']

--- a/start.ps1
+++ b/start.ps1
@@ -172,7 +172,7 @@ switch ($DRAFT) {
     }
     'dflash2' {
         $draftDir = $env:DRAFT_DIR; if (-not $draftDir)
-        $draftDir =  =~ s/.*/        { $draftDir = $cfg['DRAFT_DIR'] }/r
+        { $draftDir = $cfg['DRAFT_DIR'] }
         if (-not $draftDir -or $draftDir -eq 'none') {
             $draftDir = 'models/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
         }

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,180 @@
+#!/usr/bin/env pwsh
+# Start the OpenAI-compatible exllamav3 server (tools/serve_openai.py).
+# Native Windows port of start.sh. Configuration lives in .env.
+# First run needs cl.exe + nvcc on PATH: launch from a VS Developer
+# prompt (vcvars64.bat, x64) so the CUDA extension precompile can build.
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+if (-not (Test-Path tools/serve_openai.py)) {
+    Write-Error 'tools/serve_openai.py not found. Run from the engine repo or deployment kit.'
+    exit 1
+}
+if (-not (Test-Path .env)) {
+    Copy-Item .env.example .env
+    Write-Host 'Created .env from .env.example. Edit it (HF_TOKEN, MODEL_DIR) and rerun.'
+    exit 1
+}
+
+# Load .env (KEY=VALUE, # comments). Same file format as start.sh.
+$cfg = @{}
+Get-Content .env | ForEach-Object {
+    if ($_ -match '^\s*#' -or $_ -notmatch '=') {
+        return
+    }
+    $k, $v = $_.Split('=', 2)
+    $cfg[$k.Trim()] = $v.Trim()
+}
+if ($cfg['HF_TOKEN']) {
+    $env:HF_TOKEN = $cfg['HF_TOKEN']
+}
+
+$VenvPython = Join-Path $PWD '.venv/Scripts/python.exe'
+function Test-EngineImport {
+    & $VenvPython -c 'import torch, exllamav3, aiohttp, huggingface_hub, transformers' 2>$null
+    return $LASTEXITCODE -eq 0
+}
+if (-not (Test-Path $VenvPython) -or -not (Test-EngineImport)) {
+    Write-Host 'First-run setup (later runs skip to the model):'
+    python -m venv .venv
+    & $VenvPython -m pip install --quiet --upgrade pip setuptools wheel typing_extensions packaging
+    $torchIndex = $cfg['TORCH_INDEX_URL']
+    if (-not $torchIndex) {
+        $torchIndex = 'https://download.pytorch.org/whl/cu130'
+    }
+    & $VenvPython -m pip install torch --extra-index-url $torchIndex
+    & $VenvPython -m pip install triton-windows
+    # Engine deps minus flash-linear-attention (no Windows wheel; unused by
+    # the Qwen3.8 qwen3/dflash2/MTP path). --no-deps on the engine install
+    # below keeps pip from resolving it. transformers renders the HF chat
+    # template at request time.
+    & $VenvPython -m pip install tokenizers numpy rich typing_extensions safetensors ninja pillow pyyaml marisa_trie pydantic 'llguidance>=1.7.0' transformers
+    # The precompile needs the x64 MSVC tools + matching env. Without cl.exe
+    # the extension cannot build, so stop instead of serving a broken venv.
+    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+        Write-Error 'cl.exe not on PATH. Rerun from a VS Developer prompt (vcvars64.bat, x64) for the CUDA precompile.'
+        exit 1
+    }
+    if (-not $env:CUDA_HOME) {
+        $env:CUDA_HOME = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3'
+    }
+    if (-not $env:MAX_JOBS) {
+        $env:MAX_JOBS = '4'
+    }
+    $env:DISTUTILS_USE_SDK = '1'
+    & $VenvPython -m pip install --no-deps --no-build-isolation .
+    & $VenvPython -m pip install --quiet aiohttp huggingface_hub
+    Write-Host 'Setup complete.'
+}
+
+$PYTHON = $VenvPython
+$env:PATH = (Join-Path $PWD '.venv/Scripts') + ';' + $env:PATH
+
+$MODEL_DIR = $cfg['MODEL_DIR']; if (-not $MODEL_DIR) {
+    Write-Error 'MODEL_DIR must be set in .env'; exit 1
+}
+$PORT = $cfg['PORT']; if (-not $PORT) {
+    $PORT = '8888'
+}
+$HOST_ = $cfg['HOST']; if (-not $HOST_) {
+    $HOST_ = '127.0.0.1'
+}
+$CONTEXT_SIZE = [int]($cfg['CONTEXT_SIZE']); if (-not $CONTEXT_SIZE) {
+    $CONTEXT_SIZE = 65536
+}
+$GPU_MEM_GB = $cfg['GPU_MEM_GB']
+if (-not $GPU_MEM_GB) {
+    $vram = (nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>$null | Select-Object -First 1)
+    if ([int]$vram -gt 0) {
+        $GPU_MEM_GB = [string]([int]$vram / 1024 - 2)
+    } else {
+        $GPU_MEM_GB = '22'
+    }
+    Write-Host "GPU_MEM_GB not set. Budget: $GPU_MEM_GB GB (override in .env)"
+}
+$CACHE_QUANT = $cfg['CACHE_QUANT']; if (-not $CACHE_QUANT) {
+    $CACHE_QUANT = 'none'
+}
+$CPU_CACHE_GB = $cfg['CPU_CACHE_GB']; if (-not $CPU_CACHE_GB) {
+    $CPU_CACHE_GB = '0'
+}
+
+$DRAFT = $cfg['DRAFT']
+if (-not $DRAFT) {
+    if ($cfg['DRAFT_DIR'] -eq 'none') {
+        $DRAFT = 'none'
+    } elseif ($cfg['DRAFT_DIR']) {
+        $DRAFT = 'dflash2'
+    } else {
+        $DRAFT = 'mtp'
+    }
+}
+$DRAFT = $DRAFT.ToLower()
+
+$HF_TARGET_REPO = $cfg['HF_TARGET_REPO']; if (-not $HF_TARGET_REPO) {
+    $HF_TARGET_REPO = 'Mia-AiLab/Qwen3.8-27B-EXL3-3.5bpw'
+}
+$HF_DRAFT_REPO = $cfg['HF_DRAFT_REPO']; if (-not $HF_DRAFT_REPO) {
+    $HF_DRAFT_REPO = 'Mia-AiLab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
+}
+
+function Get-Model($repo, $dir, $label) {
+    if ((Test-Path (Join-Path $dir 'config.json')) -and (Get-ChildItem (Join-Path $dir '*.safetensors') -ErrorAction SilentlyContinue)) {
+        Write-Host "$label`: $dir present. Skip download."
+        return
+    }
+    Write-Host "$label`: download $repo to $dir ..."
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    & $PYTHON -c 'from huggingface_hub import snapshot_download; import sys; print(snapshot_download(repo_id=sys.argv[1], local_dir=sys.argv[2]))' $repo $dir
+}
+
+Get-Model -Repo $HF_TARGET_REPO -Dir $MODEL_DIR -Label 'target model'
+switch ($DRAFT) {
+    'mtp' {
+    }
+    'dflash2' {
+        $draftDir = $cfg['DRAFT_DIR']
+        if (-not $draftDir -or $draftDir -eq 'none') {
+            $draftDir = 'models/Qwen3.8-27B-DFlash2-EXL3-5.0bpw'
+        }
+        Get-Model -Repo $HF_DRAFT_REPO -Dir $draftDir -Label 'DFlash2 draft'
+        $cfg['DRAFT_DIR'] = $draftDir
+    }
+    'none' {
+    }
+    default {
+        Write-Error "DRAFT must be mtp, dflash2, or none (got: $DRAFT)"; exit 1
+    }
+}
+
+if ($CONTEXT_SIZE -gt 262144 -and (Test-Path (Join-Path $MODEL_DIR 'config.yarn-1m.json'))) {
+    $conf = Get-Content (Join-Path $MODEL_DIR 'config.json') -Raw
+    if ($conf -notmatch 'rope_scaling') {
+        Copy-Item (Join-Path $MODEL_DIR 'config.yarn-1m.json') (Join-Path $MODEL_DIR 'config.json')
+        Write-Host 'CONTEXT_SIZE > 262k: switched config.json to YaRN 1M variant.'
+    }
+}
+
+$cmd = @($PYTHON, '-u', 'tools/serve_openai.py', '--model', $MODEL_DIR,
+    '--host', $HOST_, '--port', $PORT, '--cache_size', "$CONTEXT_SIZE", '--grid_size', "$GPU_MEM_GB")
+if ($CACHE_QUANT -ne 'none') {
+    $cmd += @('--cache_quant', $CACHE_QUANT)
+}
+switch ($DRAFT) {
+    'mtp' {
+        $cmd += @('--draft_model', 'mtp')
+    }
+    'dflash2' {
+        $cmd += @('--draft_model', $cfg['DRAFT_DIR'])
+    }
+    'none' {
+        $cmd += @('--draft_model', 'none')
+    }
+}
+if ($CPU_CACHE_GB -ne '0') {
+    $cmd += @('--cpu_cache_size', $CPU_CACHE_GB)
+}
+
+Write-Host "Starting: $($cmd -join ' ')"
+& $cmd[0] $cmd[1..($cmd.Count - 1)]
+

--- a/start.sh
+++ b/start.sh
@@ -123,8 +123,8 @@ if [ ! -x .venv/bin/python ] \
     _quiet_step "4/5 ${_engine_note} (5–20 min depending on machine)" \
         .venv/bin/pip install --no-build-isolation \
             "${_engine_src}"
-    _quiet_step "5/5 server dependencies (aiohttp, huggingface_hub)" \
-        .venv/bin/pip install --quiet aiohttp huggingface_hub
+    _quiet_step "5/5 server dependencies (aiohttp, huggingface_hub, transformers)" \
+        .venv/bin/pip install --quiet aiohttp huggingface_hub transformers
     echo "Setup complete."
 fi
 

--- a/stop.ps1
+++ b/stop.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+# stop.ps1 - stop the server started by start.ps1 (graceful, then forced).
+# Windows counterpart to stop.sh. Reads PORT from .env (default 8888).
+# Safe to run when nothing is up. Refuses to kill a non-server listener.
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+$PORT = $env:PORT
+if (-not $PORT -and (Test-Path .env)) {
+    $line = Get-Content .env | Where-Object { $_ -match '^\s*PORT\s*=' } | Select-Object -First 1
+    if ($line) {
+        $PORT = $line.Split('=', 2)[1].Trim()
+    }
+}
+if (-not $PORT) {
+    $PORT = '8888'
+}
+
+$conn = Get-NetTCPConnection -LocalPort $PORT -State Listen -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if (-not $conn) {
+    Write-Host "No server listening on port $PORT."
+    exit 0
+}
+
+$proc = Get-CimInstance Win32_Process -Filter "ProcessId = $($conn.OwningProcess)" -ErrorAction SilentlyContinue
+if (-not $proc -or $proc.CommandLine -notmatch 'serve_openai') {
+    Write-Host "Port $PORT is held by another process (pid $($conn.OwningProcess))."
+    Write-Host 'Refusing to kill it.'
+    exit 1
+}
+
+Write-Host "Stopping server (pid $($conn.OwningProcess)) on port $PORT..."
+taskkill /PID $conn.OwningProcess | Out-Null
+for ($i = 0; $i -lt 20; $i++) {
+    Start-Sleep -Milliseconds 500
+    $still = Get-NetTCPConnection -LocalPort $PORT -State Listen -ErrorAction SilentlyContinue
+    if (-not $still) {
+        Write-Host 'Stopped.'
+        exit 0
+    }
+}
+
+Write-Host 'Still running after 10s, forcing...'
+taskkill /F /PID $conn.OwningProcess | Out-Null
+Start-Sleep 1
+if (Get-NetTCPConnection -LocalPort $PORT -State Listen -ErrorAction SilentlyContinue) {
+    Write-Host "ERROR: port $PORT still open."
+    exit 1
+}
+Write-Host 'Stopped.'
+

--- a/tools/serve_openai.py
+++ b/tools/serve_openai.py
@@ -42,6 +42,10 @@ MODEL_DIR = "test_models/Qwen3.8-27B-exl3-3.5bpw-wm"
 DRAFT_DIR = "mtp"   # default drafting method: MTP head (no external draft model)
 PORT = 8888
 
+# Suppress Qwen thinking traces in API completions when NO_THINKING=1.
+import os
+NO_THINKING = os.environ.get("NO_THINKING", "") == "1"
+
 gen_lock = threading.Lock()          # serialize generation (batch-1 draft)
 stats_lock = threading.Lock()
 # Cumulative counters for sparkDash live tok/s (GET /health).
@@ -293,7 +297,7 @@ def generate_full(generator, tokenizer, messages, max_tokens, temperature,
         else:
             messages = [{"role": "system", "content": directive}] + messages
     input_ids = tokenizer.hf_chat_template(
-        messages, add_generation_prompt = True, enable_thinking = True,
+        messages, add_generation_prompt = True, enable_thinking = not NO_THINKING,
         tools = tools)
     prompt_toks = int(input_ids.shape[-1])
     from exllamav3.generator.sampler.presets import ComboSampler
@@ -475,7 +479,7 @@ async def chat_completions(request):
                     req["seed"], req["tools"], req["tool_choice"], req["stop"],
                     on_text = None if forced_choice else on_text)
                 loop.call_soon_threadsafe(queue.put_nowait,
-                                          ("done", (calls, finish, reasoning, content)))
+                                          ("done", (calls, finish, reasoning, content, ptoks, otoks)))
             except Exception as e:
                 loop.call_soon_threadsafe(queue.put_nowait, ("error", str(e)))
         loop.run_in_executor(None, worker)
@@ -489,7 +493,7 @@ async def chat_completions(request):
 
         pending, finish, calls_emitted = "", None, False
         call_idx = [0]
-        in_think = [True]          # generation starts inside <think> (template)
+        in_think = [not NO_THINKING]  # generation starts inside <think> unless suppressed
         THINK_CLOSE = "</think>"
 
         async def send_call(c):
@@ -553,7 +557,7 @@ async def chat_completions(request):
                 pending += payload
                 await flush_pending()
             elif kind == "done":
-                calls, finish, reasoning, content = payload
+                calls, finish, reasoning, content, ptoks, otoks = payload
                 await flush_pending(final = True)
                 if forced_choice:
                     # Buffered path (no deltas were streamed): emit the
@@ -566,6 +570,13 @@ async def chat_completions(request):
                     for c in calls:
                         await send_call(c)
                 await send({}, finish = finish)
+                # Emit OpenAI usage chunk (bench harness reads usage)
+                usage_chunk = {"id": cid, "object": "chat.completion.chunk",
+                               "created": int(time.time()), "model": model_id,
+                               "choices": [], "usage": {
+                                   "prompt_tokens": ptoks, "completion_tokens": otoks,
+                                   "total_tokens": ptoks + otoks}}
+                await resp.write(f"data: {json.dumps(usage_chunk)}\n\n".encode())
                 await resp.write(b"data: [DONE]\n\n")
                 break
         await resp.write_eof()


### PR DESCRIPTION
What
- Add start.ps1/stop.ps1: PowerShell ports of start.sh/stop.sh sharing the same .env format. Tested on RTX 3090 with MTP drafting.
- Add transformers to the kit start.sh server deps (same 500-on-fresh-install bug as the engine).
- README: Windows quickstart paragraph, including the 3090 CACHE_QUANT=4 pointer.

Why
- Windows users following this kit have no launch path; start.sh cannot run under pwsh.exe.
- Fresh installs 500 on every chat completion: the server lazy-imports transformers for the HF chat template and nothing installs it.

Test
- RTX 3090, MTP, Hadamard 8,4 KV at 192k: /health ok, completions verified.
- Engine-side dep fix filed separately as MiaAI-Lab/exllamav3#3.